### PR TITLE
Add delete button for user's own hot takes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -393,6 +393,33 @@ body {
   margin-bottom: 8px;
 }
 
+.take-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.take-delete-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: color var(--transition-speed), background var(--transition-speed);
+}
+
+.take-delete-btn:hover {
+  color: var(--danger);
+  background: #fef2f2;
+}
+
+.take-delete-btn:active {
+  transform: scale(0.9);
+}
+
 .take-author {
   font-size: 0.85rem;
   font-weight: 600;

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -169,5 +169,15 @@ const DB = (() => {
     return result;
   }
 
-  return { init, isReady, getReactions, toggleReaction, getTakes, addTake, getVotes, castVote, saveRanking, getRanking, getAllRankings };
+  // Delete a take and all its associated votes.
+  async function deleteTake(takeId) {
+    if (!firebaseReady) return;
+    const batch = db.batch();
+    batch.delete(db.collection('takes').doc(takeId));
+    const votes = await db.collection('votes').where('takeId', '==', takeId).get();
+    votes.forEach(doc => batch.delete(doc.ref));
+    await batch.commit();
+  }
+
+  return { init, isReady, getReactions, toggleReaction, getTakes, addTake, deleteTake, getVotes, castVote, saveRanking, getRanking, getAllRankings };
 })();


### PR DESCRIPTION
Users can now delete takes they authored via an × button shown next to the timestamp. The button only appears on takes belonging to the current user. Deleting also cleans up associated votes in Firestore.

https://claude.ai/code/session_01UuWbTceFDp5S5rFkvSQVZW