### PR TITLE
Add client-side feed summary briefing card

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -600,6 +600,31 @@ body {
   to { transform: rotate(360deg); }
 }
 
+/* === Feed Summary Briefing Card === */
+.feed-summary {
+  background: linear-gradient(135deg, var(--navy) 0%, #003a66 100%);
+  border-radius: var(--radius);
+  padding: 14px 18px;
+  margin-bottom: 12px;
+  animation: fadeInUp 0.35s ease both;
+}
+
+.feed-summary-label {
+  display: block;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--green);
+  margin-bottom: 6px;
+}
+
+.feed-summary-text {
+  font-size: 0.85rem;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.88);
+}
+
 /* === Feed Filters === */
 .feed-filters {
   display: flex;


### PR DESCRIPTION
Generates a one-paragraph "Today's Briefing" at the top of the feed
using purely client-side extractive logic — no external API or cost.
Scans the top 15 article titles for trending keywords (via word
frequency, stop-word filtered) and source distribution, then assembles
a concise paragraph with today's date, source count, buzz topics, and
the lead headline.

https://claude.ai/code/session_01MPkzSFVHhWAQALm539XRwM