### PR TITLE
Add Seahawks next game countdown and live score card

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -600,6 +600,159 @@ body {
   to { transform: rotate(360deg); }
 }
 
+/* === Seahawks Game Card === */
+.game-card {
+  background: linear-gradient(135deg, var(--navy) 0%, #003a66 100%);
+  border-radius: var(--radius);
+  padding: 14px 18px;
+  margin-bottom: 14px;
+  animation: fadeInUp 0.35s ease both;
+}
+
+.game-card--live {
+  outline: 2px solid var(--green);
+  animation: pulseGlow 2s ease-in-out infinite;
+}
+
+.game-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.game-card-label {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--green);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.game-card-date,
+.game-card-clock {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.game-card-matchup {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.game-card-team {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  flex: 1;
+}
+
+.game-card-logo {
+  width: 54px;
+  height: 54px;
+  object-fit: contain;
+}
+
+.game-card-name {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.82);
+  text-align: center;
+}
+
+.game-card-score {
+  font-size: 1.7rem;
+  font-weight: 800;
+  color: rgba(255, 255, 255, 0.45);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.game-card-score.leading {
+  color: var(--white);
+}
+
+.game-card-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 72px;
+}
+
+.game-card-loc {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.game-card-countdown {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--white);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  text-align: center;
+  min-height: 1.4em;
+}
+
+.game-card-center--score {
+  font-size: 1.5rem;
+  font-weight: 300;
+  color: rgba(255, 255, 255, 0.35);
+  align-self: center;
+  padding-bottom: 4px;
+}
+
+.game-card-venue {
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.38);
+  text-align: center;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.game-result {
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  padding: 2px 9px;
+  border-radius: 5px;
+}
+
+.game-result--win {
+  background: rgba(105, 190, 40, 0.2);
+  color: var(--green);
+}
+
+.game-result--loss {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+/* Pulsing red dot shown during live games */
+.live-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  background: #ef4444;
+  border-radius: 50%;
+  animation: livePulse 1.4s ease-in-out infinite;
+}
+
+@keyframes livePulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.65); }
+}
+
 /* === Feed Summary Briefing Card === */
 .feed-summary {
   background: linear-gradient(135deg, var(--navy) 0%, #003a66 100%);

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
 
   <main class="app-main">
     <section id="view-feed" class="view active">
+      <div id="seahawks-game"></div>
       <div id="feed-list" class="card-list">
         <!-- News cards rendered here -->
       </div>
@@ -68,6 +69,7 @@
   <script src="js/feed.js"></script>
   <script src="js/takes.js"></script>
   <script src="js/rankings.js"></script>
+  <script src="js/game.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   DB.init();     // initialize Firebase wrapper (may be local-only)
   Users.init();  // setup user selection + stored identity
+  Game.init();   // load Seahawks next game / live score card
   Feed.init();   // load and render RSS feed
   Takes.init();  // setup takes UI and form handling
   Rankings.init();

--- a/js/game.js
+++ b/js/game.js
@@ -1,0 +1,218 @@
+const Game = (() => {
+  const SCHEDULE_URL =
+    'https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/sea/schedule';
+
+  let countdownTimer = null;
+  let liveInterval = null;
+
+  async function init() {
+    await refresh();
+  }
+
+  async function refresh() {
+    const container = document.getElementById('seahawks-game');
+    if (!container) return;
+
+    try {
+      const res = await fetch(SCHEDULE_URL);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const events = data.events || [];
+      const game = findRelevantGame(events);
+
+      if (!game) {
+        container.innerHTML = '';
+        return;
+      }
+
+      clearTimers();
+      renderCard(container, game);
+    } catch (e) {
+      console.warn('Game card error:', e);
+      // Silently fail — don't break the feed if ESPN is unreachable
+    }
+  }
+
+  // Find the most relevant game to display:
+  // 1. Any live game first, 2. Next upcoming game, 3. Most recently completed
+  function findRelevantGame(events) {
+    const live = events.find(e => e.competitions?.[0]?.status?.type?.state === 'in');
+    if (live) return live;
+
+    const now = Date.now();
+    const upcoming = events.find(e => {
+      const state = e.competitions?.[0]?.status?.type?.state;
+      return state === 'pre' && new Date(e.date).getTime() > now;
+    });
+    if (upcoming) return upcoming;
+
+    const completed = events.filter(e => e.competitions?.[0]?.status?.type?.state === 'post');
+    return completed.length ? completed[completed.length - 1] : null;
+  }
+
+  function getMatchup(comp) {
+    const competitors = comp.competitors || [];
+    const sea = competitors.find(c => c.team.abbreviation === 'SEA') || competitors[0];
+    const opp = competitors.find(c => c.team.abbreviation !== 'SEA') || competitors[1];
+    return { sea, opp, isHome: sea?.homeAway === 'home' };
+  }
+
+  function logoUrl(abbr) {
+    return `https://a.espncdn.com/i/teamlogos/nfl/500/${abbr.toLowerCase()}.png`;
+  }
+
+  function renderCard(container, event) {
+    const comp = event.competitions[0];
+    const state = comp.status.type.state;
+    const { sea, opp, isHome } = getMatchup(comp);
+    const locLabel = isHome ? 'vs' : 'at';
+
+    if (state === 'pre') {
+      renderUpcoming(container, event, comp, sea, opp, locLabel);
+    } else if (state === 'in') {
+      renderLive(container, comp, sea, opp);
+    } else {
+      renderFinal(container, comp, sea, opp);
+    }
+  }
+
+  function renderUpcoming(container, event, comp, sea, opp, locLabel) {
+    const gameDate = new Date(event.date);
+    const oppName = opp.team.shortDisplayName || opp.team.abbreviation;
+    const venue = comp.venue?.fullName || '';
+    const dateStr = gameDate.toLocaleDateString('en-US', {
+      weekday: 'short', month: 'short', day: 'numeric'
+    });
+    const timeStr = gameDate.toLocaleTimeString('en-US', {
+      hour: 'numeric', minute: '2-digit', timeZoneName: 'short'
+    });
+
+    container.innerHTML = `
+      <div class="game-card">
+        <div class="game-card-header">
+          <span class="game-card-label">Next Game</span>
+          <span class="game-card-date">${dateStr} · ${timeStr}</span>
+        </div>
+        <div class="game-card-matchup">
+          <div class="game-card-team">
+            <img class="game-card-logo" src="${logoUrl('sea')}" alt="Seahawks"
+              onerror="this.style.display='none'">
+            <span class="game-card-name">Seahawks</span>
+          </div>
+          <div class="game-card-center">
+            <span class="game-card-loc">${locLabel}</span>
+            <div id="game-countdown" class="game-card-countdown"></div>
+          </div>
+          <div class="game-card-team">
+            <img class="game-card-logo" src="${logoUrl(opp.team.abbreviation)}" alt="${oppName}"
+              onerror="this.style.display='none'">
+            <span class="game-card-name">${oppName}</span>
+          </div>
+        </div>
+        ${venue ? `<div class="game-card-venue">${venue}</div>` : ''}
+      </div>
+    `;
+
+    tickCountdown(gameDate);
+    countdownTimer = setInterval(() => tickCountdown(gameDate), 1000);
+  }
+
+  function tickCountdown(target) {
+    const el = document.getElementById('game-countdown');
+    if (!el) { clearInterval(countdownTimer); return; }
+
+    const diff = target - Date.now();
+    if (diff <= 0) {
+      el.textContent = '🏈 Kickoff!';
+      clearInterval(countdownTimer);
+      countdownTimer = null;
+      setTimeout(refresh, 10000);
+      return;
+    }
+
+    const d = Math.floor(diff / 86400000);
+    const h = Math.floor((diff % 86400000) / 3600000);
+    const m = Math.floor((diff % 3600000) / 60000);
+    const s = Math.floor((diff % 60000) / 1000);
+
+    el.textContent = d > 0
+      ? `${d}d ${h}h ${String(m).padStart(2, '0')}m`
+      : `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  }
+
+  function renderLive(container, comp, sea, opp) {
+    const seaScore = sea.score ?? '0';
+    const oppScore = opp.score ?? '0';
+    const clock = comp.status.displayClock || '';
+    const period = comp.status.period || 1;
+    const periodLabel = period > 4 ? 'OT' : `Q${period}`;
+    const oppName = opp.team.shortDisplayName || opp.team.abbreviation;
+    const seaLeading = parseInt(seaScore) >= parseInt(oppScore);
+
+    container.innerHTML = `
+      <div class="game-card game-card--live">
+        <div class="game-card-header">
+          <span class="game-card-label"><span class="live-dot"></span> LIVE</span>
+          <span class="game-card-clock">${clock} · ${periodLabel}</span>
+        </div>
+        <div class="game-card-matchup">
+          <div class="game-card-team">
+            <img class="game-card-logo" src="${logoUrl('sea')}" alt="Seahawks"
+              onerror="this.style.display='none'">
+            <span class="game-card-name">Seahawks</span>
+            <span class="game-card-score ${seaLeading ? 'leading' : ''}">${seaScore}</span>
+          </div>
+          <div class="game-card-center game-card-center--score">–</div>
+          <div class="game-card-team">
+            <img class="game-card-logo" src="${logoUrl(opp.team.abbreviation)}" alt="${oppName}"
+              onerror="this.style.display='none'">
+            <span class="game-card-name">${oppName}</span>
+            <span class="game-card-score ${!seaLeading ? 'leading' : ''}">${oppScore}</span>
+          </div>
+        </div>
+      </div>
+    `;
+
+    // Poll for score updates every 30 seconds
+    liveInterval = setInterval(refresh, 30000);
+  }
+
+  function renderFinal(container, comp, sea, opp) {
+    const seaScore = sea.score ?? '0';
+    const oppScore = opp.score ?? '0';
+    const seaWon = parseInt(seaScore) > parseInt(oppScore);
+    const oppName = opp.team.shortDisplayName || opp.team.abbreviation;
+    const resultClass = seaWon ? 'game-result--win' : 'game-result--loss';
+
+    container.innerHTML = `
+      <div class="game-card game-card--final">
+        <div class="game-card-header">
+          <span class="game-card-label">Final</span>
+          <span class="game-result ${resultClass}">${seaWon ? 'W' : 'L'}</span>
+        </div>
+        <div class="game-card-matchup">
+          <div class="game-card-team">
+            <img class="game-card-logo" src="${logoUrl('sea')}" alt="Seahawks"
+              onerror="this.style.display='none'">
+            <span class="game-card-name">Seahawks</span>
+            <span class="game-card-score ${seaWon ? 'leading' : ''}">${seaScore}</span>
+          </div>
+          <div class="game-card-center game-card-center--score">–</div>
+          <div class="game-card-team">
+            <img class="game-card-logo" src="${logoUrl(opp.team.abbreviation)}" alt="${oppName}"
+              onerror="this.style.display='none'">
+            <span class="game-card-name">${oppName}</span>
+            <span class="game-card-score ${!seaWon ? 'leading' : ''}">${oppScore}</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function clearTimers() {
+    if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; }
+    if (liveInterval) { clearInterval(liveInterval); liveInterval = null; }
+  }
+
+  return { init };
+})();


### PR DESCRIPTION
Adds a persistent game card at the top of the Feed tab that pulls from ESPN's public schedule API (same origin already used for power rankings). The card has three states:

- Upcoming: shows opponent logos, home/away indicator, date, venue, and a live ticking countdown (Xd Xh XXm or HH:MM:SS < 24 h out)
- Live: shows current score with the leading team highlighted, quarter and game clock, green outline pulse, and auto-refreshes every 30 s
- Final: shows final score with a W/L badge in green/red

Falls back silently if ESPN is unreachable — card is simply hidden.

https://claude.ai/code/session_01MPkzSFVHhWAQALm539XRwM