### PR TITLE
fix: remove broken RSS feeds, harden browser tests for live DB

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 504EC2FF1FED79650016851F /* Build configuration list for PBXProject "The Commission - Sports" */;
+			buildConfigurationList = 504EC2FF1FED79650016851F /* Build configuration list for PBXProject "App" */;
 			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -316,7 +316,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jbaker00.thecommission;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -338,7 +338,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jbaker00.thecommission;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
@@ -350,7 +350,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		504EC2FF1FED79650016851F /* Build configuration list for PBXProject "The Commission - Sports" */ = {
+		504EC2FF1FED79650016851F /* Build configuration list for PBXProject "App" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				504EC3141FED79650016851F /* Debug */,

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -250,6 +251,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -316,7 +318,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jbaker00.thecommission;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -338,7 +340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jbaker00.thecommission;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App.xcodeproj/xcshareddata/xcschemes/The Commission - Sports.xcscheme
+++ b/ios/App/App.xcodeproj/xcshareddata/xcschemes/The Commission - Sports.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "2620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/js/feed.js
+++ b/js/feed.js
@@ -83,13 +83,11 @@ const Feed = (() => {
 
   // List of RSS feeds to aggregate. Add/remove sources here.
   const RSS_URLS = [
-    'https://www.seahawks.com/news/rss.xml',
     'https://www.espn.com/espn/rss/nfl/news',
     'https://www.reddit.com/r/Seahawks/.rss',
     'https://www.reddit.com/r/nfl/.rss',
     'https://profootballtalk.nbcsports.com/feed/',
     'https://www.cbssports.com/rss/headlines/nfl/',
-    'https://www.nfl.com/rss/rsslanding?searchString=home'
   ];
 
   // Public RSS -> JSON proxy used to fetch feeds in-browser.

--- a/js/feed.js
+++ b/js/feed.js
@@ -83,11 +83,13 @@ const Feed = (() => {
 
   // List of RSS feeds to aggregate. Add/remove sources here.
   const RSS_URLS = [
+    'https://www.seahawks.com/rss/news',
     'https://www.espn.com/espn/rss/nfl/news',
     'https://www.reddit.com/r/Seahawks/.rss',
     'https://www.reddit.com/r/nfl/.rss',
     'https://profootballtalk.nbcsports.com/feed/',
     'https://www.cbssports.com/rss/headlines/nfl/',
+    'https://sports.yahoo.com/nfl/rss.xml',
   ];
 
   // Public RSS -> JSON proxy used to fetch feeds in-browser.
@@ -369,6 +371,7 @@ const Feed = (() => {
       if (host.includes('reddit')) return 'r/NFL';
       if (host.includes('nbcsports') || host.includes('profootballtalk')) return 'PFT';
       if (host.includes('cbssports')) return 'CBS Sports';
+      if (host.includes('yahoo')) return 'Yahoo Sports';
       if (host.includes('nfl.com')) return 'NFL';
       return host.split('.')[0];
     } catch {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -39,3 +39,34 @@ CREATE TABLE IF NOT EXISTS rankings (
   ranking jsonb NOT NULL,
   updated_at bigint NOT NULL
 );
+
+-- ============================================================
+-- Row Level Security
+-- The app uses the anon key only (no Supabase Auth).
+-- RLS is enabled to satisfy security requirements; policies
+-- grant the anon role the access the app needs.
+-- ============================================================
+
+ALTER TABLE reactions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE takes     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE votes     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE rankings  ENABLE ROW LEVEL SECURITY;
+
+-- reactions: public read, anon can insert/delete
+CREATE POLICY "reactions_select" ON reactions FOR SELECT TO anon USING (true);
+CREATE POLICY "reactions_insert" ON reactions FOR INSERT TO anon WITH CHECK (true);
+CREATE POLICY "reactions_delete" ON reactions FOR DELETE TO anon USING (true);
+
+-- takes: public read, anon can insert
+CREATE POLICY "takes_select" ON takes FOR SELECT TO anon USING (true);
+CREATE POLICY "takes_insert" ON takes FOR INSERT TO anon WITH CHECK (true);
+
+-- votes: public read, anon can insert/delete
+CREATE POLICY "votes_select" ON votes FOR SELECT TO anon USING (true);
+CREATE POLICY "votes_insert" ON votes FOR INSERT TO anon WITH CHECK (true);
+CREATE POLICY "votes_delete" ON votes FOR DELETE TO anon USING (true);
+
+-- rankings: public read, anon can insert/update
+CREATE POLICY "rankings_select" ON rankings FOR SELECT TO anon USING (true);
+CREATE POLICY "rankings_insert" ON rankings FOR INSERT TO anon WITH CHECK (true);
+CREATE POLICY "rankings_update" ON rankings FOR UPDATE TO anon USING (true) WITH CHECK (true);

--- a/tests/browser.mjs
+++ b/tests/browser.mjs
@@ -163,14 +163,19 @@ try {
           const card = cards.find(c => c.textContent.includes(text));
           const btn = card && card.querySelector('.vote-btn[data-vote="agree"], .vote-btn.agree');
           return btn && btn.classList.contains('active');
-        }, 'Seahawks are winning the Super Bowl!', { timeout: 10000 }).catch(() => null);
+        }, 'Seahawks are winning the Super Bowl!', { timeout: 20000 }).catch(() => null);
         const newTakeCard2 = page.locator('.take-card', { hasText: 'Seahawks are winning the Super Bowl!' }).first();
         const agreeActive = await newTakeCard2.locator('.vote-btn.agree, .vote-btn[data-vote="agree"]').first().evaluate(el => el.classList.contains('active'));
         agreeActive ? pass('Agree vote button active after click') : fail('Agree active', 'Not active');
 
         // Switch to disagree
         await newTakeCard2.locator('.vote-btn.disagree, .vote-btn[data-vote="disagree"]').first().click();
-        await page.waitForTimeout(1000);
+        await page.waitForFunction(text => {
+          const cards = Array.from(document.querySelectorAll('.take-card'));
+          const card = cards.find(c => c.textContent.includes(text));
+          const btn = card && card.querySelector('.vote-btn[data-vote="disagree"], .vote-btn.disagree');
+          return btn && btn.classList.contains('active');
+        }, 'Seahawks are winning the Super Bowl!', { timeout: 20000 }).catch(() => null);
         const newTakeCard3 = page.locator('.take-card', { hasText: 'Seahawks are winning the Super Bowl!' }).first();
         const disagreeActive   = await newTakeCard3.locator('.vote-btn.disagree, .vote-btn[data-vote="disagree"]').first().evaluate(el => el.classList.contains('active'));
         const agreeStillActive = await newTakeCard3.locator('.vote-btn.agree, .vote-btn[data-vote="agree"]').first().evaluate(el => el.classList.contains('active'));
@@ -178,7 +183,12 @@ try {
 
         // Toggle off: click disagree again
         await newTakeCard3.locator('.vote-btn.disagree, .vote-btn[data-vote="disagree"]').first().click();
-        await page.waitForTimeout(1000);
+        await page.waitForFunction(text => {
+          const cards = Array.from(document.querySelectorAll('.take-card'));
+          const card = cards.find(c => c.textContent.includes(text));
+          const btn = card && card.querySelector('.vote-btn[data-vote="disagree"], .vote-btn.disagree');
+          return btn && !btn.classList.contains('active');
+        }, 'Seahawks are winning the Super Bowl!', { timeout: 20000 }).catch(() => null);
         const newTakeCard4 = page.locator('.take-card', { hasText: 'Seahawks are winning the Super Bowl!' }).first();
         const disagreeOff = await newTakeCard4.locator('.vote-btn.disagree, .vote-btn[data-vote="disagree"]').first().evaluate(el => el.classList.contains('active'));
         !disagreeOff ? pass('Vote toggle off removes active class') : fail('Vote toggle off', 'Still active');


### PR DESCRIPTION
## Changes

Fixes #26 — Remove broken RSS feeds (seahawks.com, nfl.com returning 422)
Fixes #27 — Add Seahawks official RSS feed and Yahoo Sports NFL feed  
Fixes #28 — Add Supabase Row Level Security policies to schema
Fixes #29 — Harden browser tests to work with pre-existing live DB state
Fixes #30 — Update iOS build settings to Xcode recommended configuration

## Details

**RSS fixes**
- Removed dead `seahawks.com` and `nfl.com` URLs that were causing 422 console errors
- Added `seahawks.com/rss/news` (official team news, 10 articles)
- Added `sports.yahoo.com/nfl/rss.xml` (NFL coverage, 10 articles)
- App now has 7 working sources: Seahawks, ESPN, r/Seahawks, r/NFL, PFT, CBS Sports, Yahoo Sports

**Supabase**
- Added RLS policies to `supabase/schema.sql` for all 4 tables (reactions, takes, votes, rankings)

**Tests**
- Reaction and vote tests now work correctly against a live shared DB with accumulated data
- All 37 tests pass with 0 console errors

**iOS**
- Updated build number and applied Xcode recommended project settings